### PR TITLE
fix: make friendly with Helm3 and k8s 1.22

### DIFF
--- a/deploy/helm-charts/linux-audit-exporter/Chart.yaml
+++ b/deploy/helm-charts/linux-audit-exporter/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-appVersion: 0.2.2
+apiVersion: v2
+appVersion: 0.2.3
 description: >-
   linux-audit-exporter collects Linux audit metrics and exports in Prometheus
   format.
@@ -13,4 +13,4 @@ keywords:
 name: linux-audit-exporter
 sources:
   - 'https://github.com/TeachersPayTeachers/linux-audit-exporter'
-version: 0.2.2
+version: 0.2.3

--- a/deploy/helm-charts/linux-audit-exporter/values.yaml
+++ b/deploy/helm-charts/linux-audit-exporter/values.yaml
@@ -65,7 +65,7 @@ securityContext:
     # Drop security context capabilities.
     drop: ["all"]
   # Set to true to increase attack cost.
-  readOnlyFileSystem: true
+  readOnlyRootFilesystem: true
   # To read from a netlink multicast group, processes require
   # an effective UID of 0 or CAP_NET_ADMIN.
   runAsUser: 0


### PR DESCRIPTION
We are going migrate our helm release from Helm2 to Helm3 version. during that migration we found that readOnlyFileSystem is deprecated and it was replaces with readOnlyRootFilesystem 